### PR TITLE
Use `set` instead of WeakSet in TaskGroup

### DIFF
--- a/src/aiotools/taskgroup/base_compat.py
+++ b/src/aiotools/taskgroup/base_compat.py
@@ -29,7 +29,6 @@ try:
 except ImportError:
     has_contextvars = False
 import itertools
-import weakref
 
 from ..compat import current_task, get_running_loop
 from .common import create_task_with_name, patch_task
@@ -60,7 +59,7 @@ class TaskGroup:
         self._loop = get_running_loop()
         self._parent_task = None
         self._parent_cancel_requested = False
-        self._tasks = weakref.WeakSet()
+        self._tasks = set()
         self._unfinished_tasks = 0
         self._errors = []
         self._base_error = None


### PR DESCRIPTION
Fix bug with task leaking from a `TaskGroup`.